### PR TITLE
Add email and password to user update parameters

### DIFF
--- a/lib/tableau_api/resources/users.rb
+++ b/lib/tableau_api/resources/users.rb
@@ -28,7 +28,7 @@ module TableauApi
         @client.connection.api_get_collection(url, 'users.user')
       end
 
-      def update_user(user_id:, site_role:)
+      def update_user(user_id:, site_role:, password: nil, email: nil)
         raise 'invalid site_role' unless SITE_ROLES.include? site_role
 
         res = @client.connection.api_get("sites/#{@client.auth.site_id}/users/#{user_id}")
@@ -37,7 +37,11 @@ module TableauApi
         user = res['tsResponse']['user']
 
         request = Builder::XmlMarkup.new.tsRequest do |ts|
-          ts.user(name: user['name'], siteRole: site_role)
+          user_params = { name: user['name'], siteRole: site_role }
+          user_params[:password] = password if password
+          user_params[:email] = email if email
+
+          ts.user(user_params)
         end
 
         res = @client.connection.api_put("sites/#{@client.auth.site_id}/users/#{user_id}", body: request)

--- a/lib/tableau_api/version.rb
+++ b/lib/tableau_api/version.rb
@@ -1,3 +1,3 @@
 module TableauApi
-  VERSION = '1.1.2'.freeze
+  VERSION = '1.1.2.1'.freeze
 end

--- a/spec/fixtures/vcr_cassettes/users.yml
+++ b/spec/fixtures/vcr_cassettes/users.yml
@@ -628,4 +628,102 @@ http_interactions:
         </tsResponse>
     http_version: 
   recorded_at: Fri, 06 Jan 2017 02:44:34 GMT
+- request:
+    method: put
+    uri: http://localhost:2000/api/2.0/sites/5a62de1a-5553-447d-a4bd-0977db6a7b3f/users/e1b91057-9cd9-4009-b6c9-cd18f1dc3fb4
+    body:
+      encoding: UTF-8
+      string: <tsRequest><user name="test" siteRole="Viewer" email="user@example.com"/></tsRequest>
+    headers:
+      X-Tableau-Auth:
+      - e67000d62d576049e4bdb13e6c0fd594
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/xml;charset=utf-8
+      Date:
+      - Fri, 06 Jan 2017 02:44:29 GMT
+      Etag:
+      - '"de449b4abce504be32fcef0d9942bc7c"'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      P3p:
+      - CP="NON"
+      Pragma:
+      - no-cache
+      Server:
+      - Tableau
+      Vary:
+      - "*,Accept-Encoding"
+      X-Runtime:
+      - '0.062000'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Content-Length:
+      - '325'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
+          <user name="test" fullName="test" email="user@example.com" siteRole="Viewer"/>
+        </tsResponse>
+    http_version: 
+  recorded_at: Fri, 06 Jan 2017 02:44:34 GMT
+- request:
+    method: put
+    uri: http://localhost:2000/api/2.0/sites/5a62de1a-5553-447d-a4bd-0977db6a7b3f/users/e1b91057-9cd9-4009-b6c9-cd18f1dc3fb4
+    body:
+      encoding: UTF-8
+      string: <tsRequest><user name="test" siteRole="Viewer" password="new_password"/></tsRequest>
+    headers:
+      X-Tableau-Auth:
+      - e67000d62d576049e4bdb13e6c0fd594
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Type:
+      - application/xml;charset=utf-8
+      Date:
+      - Fri, 06 Jan 2017 02:44:29 GMT
+      Etag:
+      - '"de449b4abce504be32fcef0d9942bc7c"'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      P3p:
+      - CP="NON"
+      Pragma:
+      - no-cache
+      Server:
+      - Tableau
+      Vary:
+      - "*,Accept-Encoding"
+      X-Runtime:
+      - '0.062000'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Content-Length:
+      - '325'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
+          <user name="test" fullName="test" email="" siteRole="Publisher" password="new_password"/>
+        </tsResponse>
+    http_version: 
+  recorded_at: Fri, 06 Jan 2017 02:44:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/resources/users_spec.rb
+++ b/spec/resources/users_spec.rb
@@ -38,6 +38,24 @@ describe TableauApi::Resources::Users, vcr: { cassette_name: 'users' } do
       expect(user_after_change['siteRole']).to eq('Publisher')
     end
 
+    it 'can change the password of a user in a site' do
+      user = client.users.list.find do |u|
+        u['name'] == 'test'
+      end
+      expect(user['password']).to be_nil
+      user_after_change = client.users.update_user(user_id: user['id'], site_role: 'Viewer', password: 'new_password')
+      expect(user_after_change['password']).to eq('new_password')
+    end
+
+    it 'can change the email of a user in a site' do
+      user = client.users.list.find do |u|
+        u['name'] == 'test'
+      end
+      expect(user['email']).to be_nil
+      user_after_change = client.users.update_user(user_id: user['id'], site_role: 'Viewer', email: 'user@example.com')
+      expect(user_after_change['email']).to eq('user@example.com')
+    end
+
     it 'raises an error if the site role is not valid' do
       user = client.users.list.find do |u|
         u['name'] == 'test'


### PR DESCRIPTION
This allows us to set user emails and passwords through the Tableau API

https://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Update_User